### PR TITLE
Corrected interval steps for MAP, AC and NM

### DIFF
--- a/suffersync.py
+++ b/suffersync.py
@@ -400,17 +400,21 @@ def main():
                                 # Not sure if required, in my data this always seems to be the same as ftp
                                 if 'twentyMin' in item['parameters']:
                                     twentyMin = item['parameters']['twentyMin']['value']
-                                    power = max(power, twentyMin)
+                                    power = twentyMin
+                                    absolute_power = round(power * rider_ftp)
                                 # If map value exists, set ftp to the higher value of either map or ftp.
                                 if 'map' in item['parameters']:
                                     map = item['parameters']['map']['value'] * round(rider_map / rider_ftp, 2)
-                                    power = max(power, map)
+                                    power = map
+                                    absolute_power = round(power * rider_ftp)
                                 if 'ac' in item['parameters']:
                                     ac = item['parameters']['ac']['value'] * round(rider_ac / rider_ftp, 2)
-                                    power = max(power, ac)
+                                    power = ac
+                                    absolute_power = round(power * rider_ftp)
                                 if 'nm' in item['parameters']:
                                     nm = item['parameters']['nm']['value'] * round(rider_nm / rider_ftp, 2)
-                                    power = max(power, nm)
+                                    power = nm
+                                    absolute_power = round(power * rider_ftp)
                                 if power:
                                     if 'rpm' in item['parameters']:
                                         rpm = item['parameters']['rpm']['value']

--- a/suffersync.py
+++ b/suffersync.py
@@ -418,9 +418,9 @@ def main():
                                 if power:
                                     if 'rpm' in item['parameters']:
                                         rpm = item['parameters']['rpm']['value']
-                                        text = f'\n\t\t<SteadyState show_avg="1" Cadence="{rpm}" Power="{power}" Duration="{seconds}"/>'
+                                        text = f'\n\t\t<SteadyState show_avg="1" Cadence="{rpm}" Power="{power}" Duration="{seconds}"/><!-- abs power: {absolute_power} -->'
                                     else:
-                                        text = f'\n\t\t<SteadyState show_avg="1" Power="{power}" Duration="{seconds}"/>'
+                                        text = f'\n\t\t<SteadyState show_avg="1" Power="{power}" Duration="{seconds}"/><!-- abs power: {absolute_power} -->'
                                     f.write(text)
                     text = r"""
     </workout>


### PR DESCRIPTION
I discovered that my workouts had wrong numbers for MAP, AC and NM intervals. I think it is wrong to the the maximum of the ftp value and the map/ac/nm value. At least, for me it gave wrong numbers.

Tested with syncing 14 Vise Grips, AC: 6 x 45s, A Very Dark Place, Blender and Violator. The numbers are correct for me now.

Also added a XML comment in the zwo file to ease debugging.