### PR TITLE
fix: intervals.icu expects application/json Content-Type

### DIFF
--- a/suffersync.py
+++ b/suffersync.py
@@ -152,7 +152,7 @@ def get_intervals_icu_headers(api_key):
     token = b64encode(f'API_KEY:{api_key}'.encode()).decode()
     headers = {
         'Authorization': f'Basic {token}',
-        'Content-Type': 'text/plain'
+        'Content-Type': 'application/json'
     }
     return headers
 


### PR DESCRIPTION
Was getting `Something went wrong: 422 Client Error:  for url: https://intervals.icu/api/v1/athlete/i32058/events` errors when trying to upload events to intervals.icu. Full error response was: `Content type 'text/plain;charset=UTF-8' not supported`.

Changed `Content-Type` to `application/json` in `get_intervals_icu_headers`.